### PR TITLE
fix: docs videos and list padding

### DIFF
--- a/docs/docs/demo/demo.mdx
+++ b/docs/docs/demo/demo.mdx
@@ -1,4 +1,8 @@
 import ReactPlayer from 'react-player/file'
+import addBillForLoginUser from '@site/static/demo/add_bill_for_login_user.mp4';
+import addBillForNonLoginUser from '@site/static/demo/add_bill_for_non_login_user.mp4';
+import autocomplete from '@site/static/demo/autocomplete.mp4';
+import signUpUser from '@site/static/demo/sign_up_user.mp4';
 
 # Demo
 
@@ -7,25 +11,25 @@ import ReactPlayer from 'react-player/file'
 <br />
 Add bill for login user
 <div style={{marginVertical: 16, backgroundColor: 'black', display: 'grid', placeItems: 'center'}}>
-    <ReactPlayer controls='true' playing url='/demo/add_bill_for_login_user.mp4' />
+    <ReactPlayer controls={true} playing url={addBillForLoginUser} />
 </div>
 
 <br />
 Add bill for non login user
 <div style={{marginVertical: 16, backgroundColor: 'black', display: 'grid', placeItems: 'center'}}>
-    <ReactPlayer controls='true' playing url='/demo/add_bill_for_non_login_user.mp4' />
+    <ReactPlayer controls={true} playing url={addBillForNonLoginUser} />
 </div>
 
 <br />
 Autocomplete category when user selects a predefined payee
 <div style={{marginVertical: 16, backgroundColor: 'black', display: 'grid', placeItems: 'center'}}>
-    <ReactPlayer controls='true' playing url='/demo/autocomplete.mp4' />
+    <ReactPlayer controls={true} playing url={autocomplete} />
 </div>
 
 <br />
 Sign up user
 <div style={{marginVertical: 16, backgroundColor: 'black', display: 'grid', placeItems: 'center'}}>
-    <ReactPlayer controls='true' playing url='/demo/sign_up_user.mp4' />    
+    <ReactPlayer controls={true} playing url={signUpUser} />
 </div>
 
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -16,6 +16,7 @@
   "dependencies": {
     "@docusaurus/core": "2.0.0-beta.18",
     "@docusaurus/preset-classic": "2.0.0-beta.18",
+    "@docusaurus/module-type-aliases": "2.1.0",
     "@mdx-js/react": "^1.6.22",
     "clsx": "^1.1.1",
     "prism-react-renderer": "^1.3.1",

--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -37,3 +37,7 @@
 [data-theme='dark'] .docusaurus-highlight-code-line {
   background-color: rgba(0, 0, 0, 0.3);
 }
+
+.contains-task-list {
+  padding-left: var(--ifm-list-left-padding) !important;
+}


### PR DESCRIPTION
#13 Fixed the padding by overriding the CSS. Apparently some docusaurus class removes the left padding.
![image](https://user-images.githubusercontent.com/1170107/194135799-c8bd9d4e-baec-4c34-8c41-1252415a0b77.png)

#14 Fixed the 404 on videos.
![image](https://user-images.githubusercontent.com/1170107/194135921-dae746f6-98ca-4d23-be88-ca18b41b2e53.png)
